### PR TITLE
Added blurb about Visual C++ redistributable

### DIFF
--- a/ci/texlive/texlive_packages
+++ b/ci/texlive/texlive_packages
@@ -25,3 +25,4 @@ pdftexcmds
 epstopdf
 epstopdf-pkg 
 pdfescape
+letltxmacro

--- a/ci/texlive/texlive_packages
+++ b/ci/texlive/texlive_packages
@@ -24,3 +24,4 @@ kvoptions
 pdftexcmds
 epstopdf
 epstopdf-pkg 
+pdfescape

--- a/ci/texlive/texlive_packages
+++ b/ci/texlive/texlive_packages
@@ -26,3 +26,4 @@ epstopdf
 epstopdf-pkg 
 pdfescape
 letltxmacro
+bitset

--- a/source/install/windows/windows.rst
+++ b/source/install/windows/windows.rst
@@ -9,7 +9,9 @@ Windows
 
 .. image:: win.jpg
 
-3. You can start Meshroom by clicking on the executable. No extra installation is required.
+3. If you don't have it installed already, you need to install the Microsoft Visual C++ Redistributable Package 2015, 2017 and 2019 available on `Microsoft's Support portal <https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads.>`.
+
+4. You can start Meshroom by clicking on the executable. No extra installation is required.
 
 .. Note::
   Do not run Meshroom as Admin. This will disable drag-and-drop.


### PR DESCRIPTION
I installed meshroom and it wasn't running, I realized it's because I was missing the Visual C++ libraries and someone might be in the same situation, so it's better to call it out from the docs instead of assuming everyone has it installed already.