### PR TITLE
Update meshroom_photogrammetry to meshroom_batch in documentation & wiki

### DIFF
--- a/source/feature-documentation/cmd/photogrammetry.rst
+++ b/source/feature-documentation/cmd/photogrammetry.rst
@@ -1,4 +1,4 @@
-``meshroom_batch formerly meshroom_photogrammetry``
+``meshroom_batch (formerly meshroom_photogrammetry)``
 ===========================
 
 Launch the full photogrammetry or panorama HDR pipeline.

--- a/source/feature-documentation/cmd/photogrammetry.rst
+++ b/source/feature-documentation/cmd/photogrammetry.rst
@@ -1,4 +1,4 @@
-``meshroom_photogrammetry``
+``meshroom_batch formerly meshroom_photogrammetry``
 ===========================
 
 Launch the full photogrammetry or panorama HDR pipeline.

--- a/source/first-steps/install/getting-meshroom/index.rst
+++ b/source/first-steps/install/getting-meshroom/index.rst
@@ -8,7 +8,7 @@ Meshroom binaries for Windows platform and Linux platform
 can be downloaded from `here <https://alicevision.github.io/#meshroom>`_.
 
 Prebuilt binaries on this page are all-in-one packages including AliceVision and all required resources.
-The pre-built binaries also contain the ``meshroom_compute`` and ``meshroom_batch``, formerly known as ``meshroom_photogrammetry`` to run and create pipelines from the command line.
+The pre-built binaries also contain the ``meshroom_compute`` and ``meshroom_batch`` (formerly known as ``meshroom_photogrammetry``) to run and create pipelines from the command line.
 
 .. note::
   Check the `changelog <https://github.com/alicevision/meshroom/blob/develop/CHANGES.md>`_ to see what features are included in the release.

--- a/source/first-steps/install/getting-meshroom/index.rst
+++ b/source/first-steps/install/getting-meshroom/index.rst
@@ -8,7 +8,7 @@ Meshroom binaries for Windows platform and Linux platform
 can be downloaded from `here <https://alicevision.github.io/#meshroom>`_.
 
 Prebuilt binaries on this page are all-in-one packages including AliceVision and all required resources.
-The pre-built binaries also contain the ``meshroom_compute`` and ``meshroom_photogrammetry`` to run and create pipelines from the command line.
+The pre-built binaries also contain the ``meshroom_compute`` and ``meshroom_batch``, formerly known as ``meshroom_photogrammetry`` to run and create pipelines from the command line.
 
 .. note::
   Check the `changelog <https://github.com/alicevision/meshroom/blob/develop/CHANGES.md>`_ to see what features are included in the release.


### PR DESCRIPTION
Update documentation to align with binary name change.

https://github.com/alicevision/meshroom/commit/37ffd7f990f4a1cf6de67df0fad1dbc4c89b74a7

@fabiencastan next time consider changing the documentation as well, it was quite a search and took some time to find what happened here.

I'm unsure how to edit the wikis: 
https://github.com/alicevision/AliceVision/wiki/CLI-Parameters
https://github.com/alicevision/meshroom/wiki/2019.2-release-notes

Any pointers would be appreciated