### PR TITLE
Update ExportAnimatedCamera.rst

### DIFF
--- a/source/feature-documentation/nodes/ExportAnimatedCamera.rst
+++ b/source/feature-documentation/nodes/ExportAnimatedCamera.rst
@@ -5,7 +5,9 @@ ExportAnimatedCamera
 
 ExportAnimatedCamera creates an Alembic animatedCamera.abc file from SFMData (e.g. for use in 3D Compositing software)
 
-The Animated Camera export feature is not optimized at the moment and requires a sequence of images with corresponding names (1-n) from the same folder. Unstructured images, naming conventions, folder structures... will not work or result in an error.
+The Animated Camera export feature is not optimized at the moment and requires a sequence of images with corresponding names (1-n) located in a single folder. Unstructured images, naming conventions, and other folder structures will not work properly.
+
+The UV maps exported by Meshroom can be used to remove lens distortion of input images in other compositing applications.
 
 settings
 
@@ -14,9 +16,12 @@ Name                      Description
 ========================= ======================================================================================
 Input SfMData             SfMData file containing a complete SfM
 SfMData Filter            A SfMData file use as filter
-Export Undistorted Images Export Undistorted Images value=True
+Export UV Maps            Exports a lens un-distortion UV map as an .exr file
+Export Undistorted Images Exports images without lens distortion
 Undistort Image Format    Image file format to use for undistorted images (\*.jpg, \*.jpg, \*.tif, \*.exr (half))
-Verbose Level             verbosity level (fatal, error, warning, info, debug, trace)
+Export Full ROD
+Correct Principal Point   Moves the center of exported UV maps and undistorted images to the calculated lens optical center when true
+Verbose Level             Verbosity level (fatal, error, warning, info, debug, trace)
 Output filepath           Output filepath for the alembic animated camera
 Output Camera Filepath    Output filename for the alembic animated camera internalFolder + 'camera.abc'
 ========================= ======================================================================================


### PR DESCRIPTION
Adds information as promised!  This PR if implemented will close #34. :)

As of creating this PR, the description for Export Full ROD is missing as I've never used it.  I assume that it exports with overscan in formats that support it (EXR) for use when the calculated optical centre is offset in order to retain all pixels from the un-distorted plate so they don't get cropped by the edges?  Once this is clarified I will add it with another commit and we should be good to go barring any other requested changes!

Line 10 should be easy to update once lens distortion maps can be exported for re-distortion in the next version by simply adding "to add or remove lens distortion".

A final note: TECHNICALLY Meshroom exports _ST maps_ and not _UV maps_.  AFAIK UV maps refer to the mapping of a texture in object space whereas ST maps refer to mapping a texture in texture space.  Minor nitpick and this PR will not address it as changing this will require larger changes both in the program and the documentation.