### PR TITLE
Update image-import-problem.rst

### DIFF
--- a/source/faq/image-import-problem/image-import-problem.rst
+++ b/source/faq/image-import-problem/image-import-problem.rst
@@ -1,6 +1,9 @@
 Images cannot be imported
 =========================
 
+If you have recently installed Meshroom and you are sure that images are
+not corrupted then install `Microsoft Visual C++ Update 3`.
+
 The import module from AliceVision has problems parsing corrupted image
 files. Some mobile phone cameras and action cams/small cameras like the
 CGO3+ from Yuneec produce images which are not valid. Most image viewers
@@ -30,6 +33,7 @@ Windows disables drag and drop on applications being run as admin.
 Note: avoid special characters/non-ASCII characters in Meshroom and
 images file paths (`#209`_)
 
+.. _Microsoft Visual C++ Update 3: https://www.microsoft.com/ru-ru/download/details.aspx?id=53840
 .. _Bad Peggy: https://www.coderslagoon.com/
 .. _check for errors: http://openpreservation.org/blog/2016/11/29/jpegvalidation/
 .. _#149: https://github.com/alicevision/meshroom/issues/149


### PR DESCRIPTION
I had reinstalled windows so no any additional software was available.
I tried to add a rig but a received `You probably have a corrupted image...`.
MessageBoxes with `MSVCP140.DLL not found` and related were hidden and appeared after a couple of tries.

And yep, Microsoft Visual C++ 2015 fixed an issue.